### PR TITLE
Add context initiation with channel bindings token

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,9 @@ impl ClientCtx {
     /// current process will be used. `target_principal` must be the
     /// service principal name of the service you intend to
     /// communicate with. This should be an spn as described by
-    /// GSSAPI, e.g. `service/host@REALM`
+    /// GSSAPI, e.g. `service/host@REALM`. If present, `channel_bindings` is
+    /// a service-specific channel binding token which will be part
+    /// of the initial communication with the server.
     ///
     /// On success a `PendingClientCtx` and a token to be sent to the
     /// server will be returned. The server will accept the client
@@ -167,22 +169,9 @@ impl ClientCtx {
         flags: InitiateFlags,
         principal: Option<&str>,
         target_principal: &str,
+        channel_bindings: Option<&[u8]>,
     ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
-        let (pending, token) = ClientCtxImpl::initiate(flags, principal, target_principal)?;
-        Ok((PendingClientCtx(pending), token))
-    }
-
-    #[cfg(unix)]
-    /// Initiate a client context as with `initiate()`, optinally passing
-    /// the channel binding token which will be incorporated into the initial
-    /// client token.
-    pub fn initiate_with_cbt(
-        cbt: Option<Vec<u8>>,
-        flags: InitiateFlags,
-        principal: Option<&str>,
-        target_principal: &str,
-    ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
-        let (pending, token) = ClientCtxImpl::initiate_with_cbt(flags, principal, target_principal, cbt)?;
+        let (pending, token) = ClientCtxImpl::initiate(flags, principal, target_principal, channel_bindings)?;
         Ok((PendingClientCtx(pending), token))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,20 @@ impl ClientCtx {
         let (pending, token) = ClientCtxImpl::initiate(flags, principal, target_principal)?;
         Ok((PendingClientCtx(pending), token))
     }
+
+    #[cfg(unix)]
+    /// Initiate a client context as with `initiate()`, optinally passing
+    /// the channel binding token which will be incorporated into the initial
+    /// client token.
+    pub fn initiate_with_cbt(
+        cbt: Option<Vec<u8>>,
+        flags: InitiateFlags,
+        principal: Option<&str>,
+        target_principal: &str,
+    ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
+        let (pending, token) = ClientCtxImpl::initiate_with_cbt(flags, principal, target_principal, cbt)?;
+        Ok((PendingClientCtx(pending), token))
+    }
 }
 
 impl K5Ctx for ClientCtx {


### PR DESCRIPTION
This PR depends on estokes/libgssapi#9, and uses it to add a method for initiating a context with optional channel binding data.

Since `initiate()` is a one-stop method, adding a data parameter must be done either by changing its signature, thus breaking compatibility, or by adding a separate method. I chose the latter and wrote `initiate_with_cbt()`.

The patch is Unix-only because I don't have access to a Windows development environment, nor much experience with developing on Windows. The patch is self-contained and usable as-is, but I understand that you may find it unacceptable if your goal is to keep cross-platform parity at all times.

Edit: my browsing of others' channel binding code makes me think that Windows support would require creating a `SecBuffer` of the type `SECBUFFER_CHANNEL_BINDINGS` and filling out the `SEC_CHANNEL_BINDINGS` structure with the token. That buffer could then be passed as input to  `InitializeSecurityContextW()` (but that's a "simple matter of programming" view and I may well be missing something).