### PR TITLE
Add ability to convert libgssapi Creds into krb5-cross credentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["iov"]
 iov = ["libgssapi/iov"]
 
 [target.'cfg(unix)'.dependencies.libgssapi]
-version = "0.8.0"
+version = "0.9.0"
 path = "../libgssapi/libgssapi"
 default-features = false
 

--- a/examples/cred.rs
+++ b/examples/cred.rs
@@ -1,0 +1,8 @@
+use cross_krb5::{Cred, K5Ctx};
+use libgssapi::credential::{Cred as GssCred, CredUsage};
+
+fn main() {
+    let mut gss_cred = GssCred::acquire(None, None, CredUsage::Accept, None).unwrap();
+    let cred: Cred = Cred::from(gss_cred); // To krb5-cross compatible
+    gss_cred = cred.into(); // and back
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,11 +89,23 @@
 //! }
 //! ```
 
+#[macro_use]
+extern crate bitflags;
 use anyhow::Result;
 use bytes::{Buf, BytesMut};
 use std::{ops::Deref, time::Duration};
-#[macro_use]
-extern crate bitflags;
+
+pub trait K5Cred: Sized {
+    fn server_acquire(
+        _flags: AcceptFlags,
+        principal: Option<&str>,
+    ) -> Result<Self>;
+
+    fn client_acquire(
+        _flags: InitiateFlags,
+        principal: Option<&str>,
+    ) -> Result<Self>;
+}
 
 pub trait K5Ctx {
     type Buffer: Deref<Target = [u8]> + Send + Sync;
@@ -148,8 +160,9 @@ mod unix;
 
 #[cfg(unix)]
 use crate::unix::{
-    ClientCtx as ClientCtxImpl, PendingClientCtx as PendingClientCtxImpl,
-    PendingServerCtx as PendingServerCtxImpl, ServerCtx as ServerCtxImpl,
+    ClientCtx as ClientCtxImpl, Cred as CredImpl,
+    PendingClientCtx as PendingClientCtxImpl, PendingServerCtx as PendingServerCtxImpl,
+    ServerCtx as ServerCtxImpl
 };
 
 #[cfg(windows)]
@@ -164,6 +177,36 @@ use crate::windows::{
 pub enum Step<C, T> {
     Finished(C),
     Continue(T),
+}
+
+#[derive(Debug)]
+pub struct Cred(CredImpl);
+impl K5Cred for Cred {
+    fn server_acquire(flags: AcceptFlags, principal: Option<&str>) -> Result<Cred> {
+        CredImpl::server_acquire(flags, principal).map(Cred)
+    }
+    fn client_acquire(flags: InitiateFlags, principal: Option<&str>) -> Result<Cred> {
+        CredImpl::client_acquire(flags, principal).map(Cred)
+    }
+}
+impl From<CredImpl> for Cred {
+    fn from(cred: CredImpl) -> Self {
+        Cred(cred)
+    }
+}
+
+#[cfg(unix)]
+impl From<libgssapi::credential::Cred> for Cred {
+    fn from(value: libgssapi::credential::Cred) -> Self {
+        Cred(CredImpl::from(value))
+    }
+}
+
+#[cfg(unix)]
+impl Into<libgssapi::credential::Cred> for Cred {
+    fn into(self) -> libgssapi::credential::Cred {
+        self.0.into()
+    }
 }
 
 /// a partly initialized client context
@@ -233,6 +276,16 @@ impl ClientCtx {
     ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
         let (pending, token) =
             ClientCtxImpl::new(flags, principal, target_principal, channel_bindings)?;
+        Ok((PendingClientCtx(pending), token))
+    }
+
+    pub fn new_with_cred(
+        cred: Cred,
+        target_principal: &str,
+        channel_bindings: Option<&[u8]>
+    ) -> Result<(PendingClientCtx, impl Deref<Target=[u8]>)> {
+        let (pending, token) =
+            ClientCtxImpl::new_with_cred(cred.0, target_principal, channel_bindings)?;
         Ok((PendingClientCtx(pending), token))
     }
 }
@@ -310,6 +363,10 @@ impl ServerCtx {
     /// client before it can be used.
     pub fn new(flags: AcceptFlags, principal: Option<&str>) -> Result<PendingServerCtx> {
         Ok(PendingServerCtx(ServerCtxImpl::new(flags, principal)?))
+    }
+
+    pub fn new_with_cred(cred: Cred) -> Result<PendingServerCtx> {
+        Ok(PendingServerCtx(ServerCtxImpl::new_with_cred(cred.0)?))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ extern crate bitflags;
 use anyhow::Result;
 use bytes::{Buf, BytesMut};
 use std::{ops::Deref, time::Duration};
+use ::windows::Win32::Security::Credentials::SecHandle;
 
 pub trait K5Cred: Sized {
     fn server_acquire(
@@ -172,6 +173,7 @@ mod windows;
 use crate::windows::{
     ClientCtx as ClientCtxImpl, PendingClientCtx as PendingClientCtxImpl,
     PendingServerCtx as PendingServerCtxImpl, ServerCtx as ServerCtxImpl,
+    Cred as CredImpl
 };
 
 pub enum Step<C, T> {
@@ -205,6 +207,20 @@ impl From<libgssapi::credential::Cred> for Cred {
 #[cfg(unix)]
 impl Into<libgssapi::credential::Cred> for Cred {
     fn into(self) -> libgssapi::credential::Cred {
+        self.0.into()
+    }
+}
+
+#[cfg(windows)]
+impl From<SecHandle> for Cred {
+    fn from(value: SecHandle) -> Self {
+        Cred(CredImpl::from(value))
+    }
+}
+
+#[cfg(windows)]
+impl Into<SecHandle> for Cred {
+    fn into(self) -> SecHandle {
         self.0.into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ pub enum Step<C, T> {
 
 #[derive(Debug)]
 pub struct Cred(CredImpl);
+
 impl K5Cred for Cred {
     fn server_acquire(flags: AcceptFlags, principal: Option<&str>) -> Result<Cred> {
         CredImpl::server_acquire(flags, principal).map(Cred)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ extern crate bitflags;
 use anyhow::Result;
 use bytes::{Buf, BytesMut};
 use std::{ops::Deref, time::Duration};
+#[cfg(windows)]
 use ::windows::Win32::Security::Credentials::SecHandle;
 
 pub trait K5Cred: Sized {
@@ -191,6 +192,7 @@ impl K5Cred for Cred {
         CredImpl::client_acquire(flags, principal).map(Cred)
     }
 }
+
 impl From<CredImpl> for Cred {
     fn from(cred: CredImpl) -> Self {
         Cred(cred)

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -94,6 +94,7 @@ fn unwrap_iov(
 
 #[derive(Debug)]
 pub(crate) struct Cred(GssCred);
+
 impl Cred {
     fn acquire(principal: Option<&str>, usage: CredUsage) -> Result<Cred> {
         let name = principal
@@ -108,6 +109,7 @@ impl Cred {
 
     }
 }
+
 impl K5Cred for Cred {
     fn server_acquire(_flags: AcceptFlags, principal: Option<&str>) -> Result<Cred> {
         Self::acquire(principal, CredUsage::Accept)
@@ -117,11 +119,13 @@ impl K5Cred for Cred {
         Self::acquire(principal, CredUsage::Initiate)
     }
 }
+
 impl From<GssCred> for Cred {
     fn from(cred: GssCred) -> Self {
         Cred(cred)
     }
 }
+
 impl Into<GssCred> for Cred {
     fn into(self) -> GssCred {
         self.0

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,5 @@
-use super::{AcceptFlags, InitiateFlags, K5Ctx, K5ServerCtx, Step};
-use anyhow::{anyhow, bail, Context};
+use super::{AcceptFlags, InitiateFlags, K5Cred, K5Ctx, K5ServerCtx, Step};
+use anyhow::{anyhow, bail, Context, Result};
 use bytes::{buf::Chain, Buf, BytesMut};
 use std::{
     default::Default,
@@ -77,7 +77,8 @@ fn format_error(error: i32) -> String {
     unsafe { string_from_wstr(msg.as_mut_ptr()) }
 }
 
-struct Cred(SecHandle);
+#[derive(Debug)]
+pub(crate) struct Cred(SecHandle);
 
 impl Drop for Cred {
     fn drop(&mut self) {
@@ -89,6 +90,11 @@ impl Drop for Cred {
 impl From<SecHandle> for Cred {
     fn from(handle: SecHandle) -> Self {
         Cred(handle)
+    }
+}
+impl Into<SecHandle> for Cred {
+    fn into(self) -> SecHandle {
+        self.0
     }
 }
 
@@ -129,6 +135,16 @@ impl Cred {
             .context("querying credential names")?;
             Ok(string_from_wstr(names.sUserName))
         }
+    }
+}
+
+impl K5Cred for Cred {
+    fn server_acquire(flags: AcceptFlags, principal: Option<&str>) -> anyhow::Result<Self> {
+        Self::acquire(flags.contains(AcceptFlags::NEGOTIATE_TOKEN), principal, true)
+    }
+
+    fn client_acquire(flags: InitiateFlags, principal: Option<&str>) -> anyhow::Result<Self> {
+        Self::acquire(flags.contains(InitiateFlags::NEGOTIATE_TOKEN), principal, false)
     }
 }
 
@@ -323,13 +339,21 @@ impl ClientCtx {
         target_principal: &str,
         cb_token: Option<&[u8]>,
     ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
+        Self::new_with_cred(
+            Cred::client_acquire(flags, principal)?,
+            target_principal,
+            cb_token,
+        )
+    }
+
+    pub(crate) fn new_with_cred(
+        cred: Cred,
+        target_principal: &str,
+        cb_token: Option<&[u8]>,
+    ) -> Result<(PendingClientCtx, impl Deref<Target = [u8]>)> {
         let mut ctx = ClientCtx {
             ctx: SecHandle::default(),
-            cred: Cred::acquire(
-                flags.contains(InitiateFlags::NEGOTIATE_TOKEN),
-                principal,
-                false,
-            )?,
+            cred,
             target: str_to_wstr(target_principal),
             attrs: 0,
             lifetime: 0,
@@ -529,13 +553,17 @@ impl ServerCtx {
         flags: AcceptFlags,
         principal: Option<&str>,
     ) -> Result<PendingServerCtx> {
+        Self::new_with_cred(
+            Cred::server_acquire(flags, principal)?
+        )
+    }
+
+    pub(crate) fn new_with_cred(
+        cred: Cred
+    ) -> Result<PendingServerCtx> {
         Ok(PendingServerCtx(ServerCtx {
             ctx: SecHandle::default(),
-            cred: Cred::acquire(
-                flags.contains(AcceptFlags::NEGOTIATE_TOKEN),
-                principal,
-                true,
-            )?,
+            cred,
             buf: alloc_krb5_buf()?,
             attrs: 0,
             lifetime: 0,
@@ -630,13 +658,13 @@ impl K5Ctx for ServerCtx {
         Ok(self.header.split().chain(msg.chain(self.padding.split())))
     }
 
-    fn unwrap_iov(&mut self, len: usize, msg: &mut BytesMut) -> Result<BytesMut> {
-        unwrap_iov(&mut self.ctx, len, msg)
-    }
-
     fn unwrap(&mut self, msg: &[u8]) -> Result<BytesMut> {
         let mut buf = BytesMut::from(msg);
         self.unwrap_iov(buf.len(), &mut buf)
+    }
+
+    fn unwrap_iov(&mut self, len: usize, msg: &mut BytesMut) -> Result<BytesMut> {
+        unwrap_iov(&mut self.ctx, len, msg)
     }
 
     fn ttl(&mut self) -> Result<Duration> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,5 +1,5 @@
 use super::{AcceptFlags, InitiateFlags, K5Ctx, K5ServerCtx, Step};
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Context};
 use bytes::{buf::Chain, Buf, BytesMut};
 use std::{
     default::Default,
@@ -84,6 +84,11 @@ impl Drop for Cred {
         unsafe {
             let _ = FreeCredentialsHandle(&mut self.0);
         }
+    }
+}
+impl From<SecHandle> for Cred {
+    fn from(handle: SecHandle) -> Self {
+        Cred(handle)
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -87,11 +87,13 @@ impl Drop for Cred {
         }
     }
 }
+
 impl From<SecHandle> for Cred {
     fn from(handle: SecHandle) -> Self {
         Cred(handle)
     }
 }
+
 impl Into<SecHandle> for Cred {
     fn into(self) -> SecHandle {
         self.0


### PR DESCRIPTION
Ran into the problem of being unable to convert krb5-cross credentials to/from libgssapi credentials, see https://github.com/inejge/ldap3/pull/147.

This PR resolves that by adding the ability to acquire and use credentials separately from the security contexts, and allowing creation of contexts using these credentials. It also adds the ability to convert native libgssapi credentials into krb5-cross creds, which makes it easier to interact with applications using both libgssapi and krb5-cross, such as in my case interacting with ldap3.

This also fixes https://github.com/estokes/cross-krb5/issues/12 for my usecase at least.

I'll look into mirroring this for windows as well.
